### PR TITLE
Stop silently eating errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ function run() {
     return createLoader().then(loader => {
       return preparePlatform(loader).then(() => {
         for (let i = 0, ii = appHost.length; i < ii; ++i) {
-          handleApp(loader, appHost[i]);
+          handleApp(loader, appHost[i]).catch(logger.error.bind(logger));
         }
 
         sharedLoader = loader;


### PR DESCRIPTION
I have been running circles around myself because of swallowed errors.
This mainly affects anything directly inside, or imported into the main.js, which causes an error.
This should fix that.

However one caveat: if the logger is not configured to output anything yet, then the error won't get logged..
My workaround for that currently is System.import("config").then(() => System.import('aurelia-bootstrapper')), where config is:

```
import {LogManager} from 'aurelia-framework';
import {ConsoleAppender} from 'aurelia-logging-console';

LogManager.addAppender(new ConsoleAppender());
LogManager.setLevel(LogManager.logLevel.debug);
```

But maybe it would be better if the error could somehow be given back all the way to the aurelia-bootstrapper import?
E.g:

```
System.import("aurelia-bootstrapper")
  .then(x => x.run())
  .catch(console.error.bind(console))
```

The run function would then need to get exported, not called automatically anymore, and a Promise.all should be returned for all handleApp and readyQueue promises.
