### PR TITLE
fix(bootstrapper): Check module function configure before execute it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,12 @@ function config(loader, appHost, configModuleId) {
   aurelia.configModuleId = configModuleId || null;
 
   if (configModuleId) {
-    return loader.loadModule(configModuleId).then(customConfig => customConfig.configure && customConfig.configure(aurelia));
+    return loader.loadModule(configModuleId).then(customConfig => { 
+      if (!customConfig.configure) {
+         throw "Cannot initialize module '" + configModuleId + "' without a configure function.";
+      }      
+      customConfig.configure(aurelia);
+    });
   }
 
   aurelia.use

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ function config(loader, appHost, configModuleId) {
   aurelia.configModuleId = configModuleId || null;
 
   if (configModuleId) {
-    return loader.loadModule(configModuleId).then(customConfig => customConfig.configure(aurelia));
+    return loader.loadModule(configModuleId).then(customConfig => customConfig.configure && customConfig.configure(aurelia));
   }
 
   aurelia.use


### PR DESCRIPTION
Prevent error 'TypeError: customConfig.configure it not a function' when a module is set by <... aurelia-app="my-module"> and my-module.js does not have exported a configure function.
