### PR TITLE
feat(index): unify bootstrappers and expose 'starting' Promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,17 @@
   "aurelia": {
     "documentation": {
       "articles": []
+    },
+    "build": {
+      "resources": [
+        "aurelia-framework",
+        "aurelia-logging-console",
+        "aurelia-templating-binding",
+        "aurelia-templating-resources",
+        "aurelia-templating-router",
+        "aurelia-history-browser",
+        "aurelia-event-aggregator"
+      ]
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -48,12 +48,12 @@ function createLoader() {
     return System.normalize('aurelia-bootstrapper').then(bootstrapperName => {
       return System.normalize('aurelia-loader-default', bootstrapperName);
     }).then(loaderName => {
-      return System.import(loaderName).then(m => new m.DefaultLoader());
+      return window.System.import(loaderName).then(m => new m.DefaultLoader());
     });
   }
 
   if (typeof window.require === 'function') {
-    return new Promise((resolve, reject) => require(['aurelia-loader-default'], m => resolve(new m.DefaultLoader()), reject));
+    return new Promise((resolve, reject) => window.require(['aurelia-loader-default'], m => resolve(new m.DefaultLoader()), reject));
   }
 
   return Promise.reject('No PLATFORM.Loader is defined and there is neither a System API (ES6) or a Require API (AMD) globally available to load your app.');
@@ -138,4 +138,4 @@ export function bootstrap(configure: Function): Promise<void> {
   });
 }
 
-run();
+export const starting = run();

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,6 @@ function config(loader, appHost, configModuleId) {
 function run() {
   return ready().then((isNode: boolean) => {
     if (!isNode) {
-      console.log(`initializing!`)
       initialize();
     }
 


### PR DESCRIPTION
With these changes we no longer need the bootstrapper-webpack repo. Webpack was complaining because of the use of `System.import` and `require` methods directly. Since they're exposed on `window`, if we use them instead, there is no problem anymore.

I also exposed the resulting Promise of the initial `run()`, so that unit tests can import it and only start after initial bootstrapping has completed (useful e.g. for Protractor).