### PR TITLE
chore(build): document dynamic dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,36 +1,21 @@
 import 'aurelia-polyfills';
 import {PLATFORM, isInitialized} from 'aurelia-pal';
 
-let bootstrapQueue = [];
-let sharedLoader = null;
-let Aurelia = null;
+let bootstrapPromises = [];
+let startResolve;
+const startPromise = new Promise(resolve => startResolve = resolve);
+
 const host = PLATFORM.global;
 const isNodeLike = typeof process !== 'undefined' && !process.browser;
 
-function onBootstrap(callback) {
-  return new Promise((resolve, reject) => {
-    if (sharedLoader) {
-      resolve(callback(sharedLoader));
-    } else {
-      bootstrapQueue.push(() => {
-        try {
-          resolve(callback(sharedLoader));
-        } catch (e) {
-          reject(e);
-        }
-      });
-    }
-  });
-}
 
 function ready() {
-  return new Promise((resolve, reject) => {
-    if (!host.document || host.document.readyState === 'complete') {
-      resolve();
-    } else {
-      host.document.addEventListener('DOMContentLoaded', completed);
-      host.addEventListener('load', completed);
-    }
+  if (!host.document || host.document.readyState === 'complete') {
+    return Promise.resolve();
+  }
+  return new Promise(resolve => {
+    host.document.addEventListener('DOMContentLoaded', completed);
+    host.addEventListener('load', completed);
 
     function completed() {
       host.document.removeEventListener('DOMContentLoaded', completed);
@@ -106,87 +91,80 @@ function initializePal(loader) {
   // Note: Please do NOT try to add PLATFORM.moduleName() annotations here.
   //       This would create a static dependency between bootstrapper and a PAL, which we don't want.
   //       The correct PAL to bundle must be determined by the bundling tool at build time.
-
   return loader.loadModule('aurelia-pal-' + type)
-    .then(palModule => type === 'nodejs' && !isInitialized && palModule.globalize() || palModule.initialize());
+               .then(palModule => type === 'nodejs' && !isInitialized && palModule.globalize() || palModule.initialize());
 }
 
 function preparePlatform(loader) {
-  // Note: Please do NOT add PLATFORM.moduleName() others than 'aurelia-framework'.
-  //       This is the _only_ module actually loaded by the bootstrapper.
-  //       The other ones are fake dependencies, if you look at the code carefully you'll 
-  //       notice that they are just some name resolutions and mapping; nothing gets loaded.
 
+  const map = (moduleId, relativeTo) => 
+    loader.normalize(moduleId, relativeTo)
+          .then(normalized => {
+            loader.map(moduleId, normalized);
+            return normalized;
+          });
+  
   return initializePal(loader)
     .then(() => loader.normalize('aurelia-bootstrapper'))
     .then(bootstrapperName => {
       // aurelia-framework re-exports pretty much everything.
       // As can be seen at the end of this method, the only field accessed by bootstrapper is `Aurelia`,
       // so we document that to enable tree shaking on all other exported members.
-      return loader.normalize(PLATFORM.moduleName('aurelia-framework', { exports: ['Aurelia'] }),
-                              bootstrapperName)
-        .then(frameworkName => {
-          loader.map('aurelia-framework', frameworkName);
-
-          return Promise.all([
-            loader.normalize('aurelia-dependency-injection', frameworkName)
-              .then(diName => loader.map('aurelia-dependency-injection', diName)),
-            loader.normalize('aurelia-router', bootstrapperName)
-              .then(routerName => loader.map('aurelia-router', routerName)),
-            loader.normalize('aurelia-logging-console', bootstrapperName)
-              .then(loggingConsoleName => loader.map('aurelia-logging-console', loggingConsoleName))
-          ]).then(() => {
-            return loader.loadModule(frameworkName).then(m => Aurelia = m.Aurelia);
-          });
-        });
-    });
+      const frameworkPromise = map(PLATFORM.moduleName('aurelia-framework', { exports: ['Aurelia'] }), 
+                                   bootstrapperName);
+      // Please do NOT add PLATFORM.moduleName() around any of those modules.
+      // They are not actually loaded here, only mapped.
+      return Promise.all([
+        frameworkPromise,
+        frameworkPromise.then(frameworkName => map('aurelia-dependency-injection', frameworkName)),
+        map('aurelia-router', bootstrapperName),
+        map('aurelia-logging-console', bootstrapperName),
+      ]);
+    })
+    .then(([frameworkName,]) => loader.loadModule(frameworkName))
+    .then(({ Aurelia }) => startResolve(() => new Aurelia(loader)));
 }
 
-function handleApp(loader, appHost) {
-  const moduleId = appHost.getAttribute('aurelia-app') || appHost.getAttribute('data-aurelia-app');
-  return config(loader, appHost, moduleId);
-}
-
-function config(loader, appHost, configModuleId) {
-  const aurelia = new Aurelia(loader);
+function config(appHost, configModuleId, aurelia) {
   aurelia.host = appHost;
   aurelia.configModuleId = configModuleId || null;
 
   if (configModuleId) {
-    return loader.loadModule(configModuleId).then(customConfig => {
-      if (!customConfig.configure) {
-        throw new Error("Cannot initialize module '" + configModuleId + "' without a configure function.");
-      }
-
-      customConfig.configure(aurelia);
-    });
+    return aurelia.loader
+                  .loadModule(configModuleId)
+                  .then(customConfig => {
+                      if (!customConfig.configure) {
+                        throw new Error(`Cannot initialize module '${configModuleId}' without a configure function.`);
+                      }
+                      return customConfig.configure(aurelia);
+                  });
   }
 
   aurelia.use
-    .standardConfiguration()
-    .developmentLogging();
+         .standardConfiguration()
+         .developmentLogging();
 
   return aurelia.start().then(() => aurelia.setRoot());
 }
 
 function run() {
   return ready()
-    .then(() => createLoader())
-    .then(loader => {
-      return preparePlatform(loader).then(() => {
-        const appHost = host.document.querySelectorAll('[aurelia-app],[data-aurelia-app]');
-        const toConsole = console.error.bind(console);
+    .then(createLoader)
+    .then(preparePlatform)
+    .then(() => {
+      const appHosts = host.document.querySelectorAll('[aurelia-app],[data-aurelia-app]');
+      for (let i = 0, ii = appHosts.length; i < ii; ++i) {
+        const appHost = appHosts[i];
+        const moduleId = appHost.getAttribute('aurelia-app') || appHost.getAttribute('data-aurelia-app');
+        bootstrap(config.bind(null, appHost, moduleId));
+      }
 
-        for (let i = 0, ii = appHost.length; i < ii; ++i) {
-          handleApp(loader, appHost[i]).catch(toConsole);
-        }
-
-        sharedLoader = loader;
-        for (let i = 0, ii = bootstrapQueue.length; i < ii; ++i) {
-          bootstrapQueue[i]();
-        }
-        bootstrapQueue = null;
-      });
+      // This can't be moved before preparePlatform. 
+      // In old IE the console object only exists after F12 tools have been opened and PAL creates a substitute.
+      const toConsole = console.error.bind(console);
+      const bootstraps = bootstrapPromises.map(p => p.catch(toConsole));
+      bootstrapPromises = null;
+      return Promise.all(bootstraps);
     });
 }
 
@@ -196,10 +174,9 @@ function run() {
  * @return A Promise that completes when configuration is done.
  */
 export function bootstrap(configure: Function): Promise<void> {
-  return onBootstrap(loader => {
-    const aurelia = new Aurelia(loader);
-    return configure(aurelia);
-  });
+  const p = startPromise.then(factory => configure(factory()));
+  if (bootstrapPromises) bootstrapPromises.push(p);
+  return p;
 }
 
 /**


### PR DESCRIPTION
Add `PLATFORM.moduleName()` around `aurelia-framework`.

Also reviewed the loading path so that no promise goes unobserved. Previously `starting` would resolve too early because several calls were not properly chained in 3 or 4 places.

Although the priority for that refactoring was clarity and correctness, the resulting minified commonjs distribution is 6% smaller.

See aurelia/pal#21