### PR TITLE
fix(loader): Use better detection of amd loaders

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ function createLoader() {
     }
 
     // AMD Module Loader Support
-    if (typeof host.require === 'function' && typeof host.require.version === 'string') {
+    if (typeof host.require === 'function' && typeof host.define === 'function' && typeof host.define.amd === 'object') {
       return new Promise((resolve, reject) => host.require(['aurelia-loader-default'], m => resolve(new m.DefaultLoader()), reject));
     }
 


### PR DESCRIPTION
Fixes: #68 

Instead of checking require.version I'm checking for amd specs https://github.com/amdjs/amdjs-api/blob/master/AMD.md#defineamd-property- 

Locally tested with alameda as replacement and it worked for me.