### PR TITLE
fix: avoid unnecessary pal loading when pal is already initialized

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,8 @@ function createLoader() {
 }
 
 function initializePal(loader) {
+  if (isInitialized) return Promise.resolve();
+
   let type;
 
   const isRenderer = isNodeLike && (process.type === 'renderer' || process.versions['node-webkit']);


### PR DESCRIPTION
aurelia-pal could be initialized before bootstrapping, such as test setup. This is to help aurelia/cli#1019 to avoid loading aurelia-pal-nodejs when aurelia-pal-browser is already loaded.